### PR TITLE
Add Query String Support to PageEntityMeta

### DIFF
--- a/AD.Exodius.Tests/Components/EntityComponentTests.cs
+++ b/AD.Exodius.Tests/Components/EntityComponentTests.cs
@@ -4,7 +4,7 @@ using AD.Exodius.Drivers;
 using AD.Exodius.Entities;
 using AD.Exodius.Events;
 using AD.Exodius.Tests.Stubs.Components;
-using AD.Exodius.Tests.Stubs.Entities.PageObjects;
+using AD.Exodius.Tests.Stubs.Entities.Pages;
 
 namespace AD.Exodius.Tests.Components;
 

--- a/AD.Exodius.Tests/Entities/Pages/Extensions/PageEntityExtensionsTests.cs
+++ b/AD.Exodius.Tests/Entities/Pages/Extensions/PageEntityExtensionsTests.cs
@@ -2,7 +2,7 @@
 using NSubstitute;
 using AD.Exodius.Entities.Pages;
 using AD.Exodius.Entities.Pages.Extensions;
-using AD.Exodius.Tests.Stubs.Entities.PageObjects;
+using AD.Exodius.Tests.Stubs.Entities.Pages;
 using AD.Exodius.Events;
 
 namespace AD.Exodius.Tests.Entities.Pages.Extensions;
@@ -93,7 +93,7 @@ public class PageEntityExtensionsTests
     }
 
     [Fact]
-    public void GetPageObjectMeta_ShouldReturnValidMeta_WhenMetaIsFound()
+    public void GetPageEntityMeta_ShouldReturnValidMeta_WhenMetaIsFound()
     {
         var meta = _metaPageEntity.GetPageEntityMeta();
 
@@ -101,10 +101,11 @@ public class PageEntityExtensionsTests
         Assert.Equal("/home", meta.Route);
         Assert.Equal("Example", meta.Name);
         Assert.Equal("test", meta.DomId);
+        Assert.Equal("?param1=value1&param2=value2", meta.QueryString);
     }
 
     [Fact]
-    public void TryGetPageObjectMeta_ShouldReturnTrueAndValidMeta_WhenMetaIsFound()
+    public void TryGetPageEntityMeta_ShouldReturnTrueAndValidMeta_WhenMetaIsFound()
     {
         var isMetaPresent = _metaPageEntity.TryGetPageEntityMeta(out var meta);
 
@@ -113,6 +114,7 @@ public class PageEntityExtensionsTests
         Assert.Equal("/home", meta.Route);
         Assert.Equal("Example", meta.Name);
         Assert.Equal("test", meta.DomId);
+        Assert.Equal("?param1=value1&param2=value2", meta.QueryString);
     }
 
     [Fact]

--- a/AD.Exodius.Tests/Entities/Pages/Factories/PageEntityFactoryTests.cs
+++ b/AD.Exodius.Tests/Entities/Pages/Factories/PageEntityFactoryTests.cs
@@ -1,7 +1,7 @@
 ﻿using AD.Exodius.Drivers;
 using NSubstitute;
 using AD.Exodius.Entities.Pages.Factories;
-using AD.Exodius.Tests.Stubs.Entities.PageObjects;
+using AD.Exodius.Tests.Stubs.Entities.Pages;
 using AD.Exodius.Events;
 
 namespace AD.Exodius.Tests.Entities.Pages.Factories;

--- a/AD.Exodius.Tests/Entities/Pages/PageEntityTests.cs
+++ b/AD.Exodius.Tests/Entities/Pages/PageEntityTests.cs
@@ -38,7 +38,7 @@ public class PageEntityTests
     {
         var page = new EventPageEntity(_driver, _eventBus);
 
-        await _eventBus.Publish(new PageReadyCheckEvent());
+        await _eventBus.PublishAsync(new PageReadyCheckEvent());
 
         Assert.True(page.WaitCalled);
     }

--- a/AD.Exodius.Tests/Helpers/UrlBuilderTests.cs
+++ b/AD.Exodius.Tests/Helpers/UrlBuilderTests.cs
@@ -32,6 +32,7 @@ public class UrlBuilderTests
     [InlineData("https://testing2.com/secure/", "/module/test", "https://testing2.com/secure/module/test/")]
     [InlineData("https://testing2.com", "/login", "https://testing2.com/login/")]
     [InlineData("https://testing2.com/secure", "/login", "https://testing2.com/login/")]
+    [InlineData("https://testing5.com/secure", "/login?param=1", "https://testing5.com/login?param=1")]
     public void AppendRoute_Should_AppendRouteCorrectly(string baseUrl, string route, string expectedUrl)
     {
         var result = UrlBuilder.AppendRoute(baseUrl, route);

--- a/AD.Exodius.Tests/Navigators/NavigatorTests.cs
+++ b/AD.Exodius.Tests/Navigators/NavigatorTests.cs
@@ -1,14 +1,12 @@
-﻿using NSubstitute;
-using AD.Exodius.Drivers;
-using AD.Exodius.Entities.Pages;
+﻿using AD.Exodius.Drivers;
 using AD.Exodius.Entities.Pages.Factories;
 using AD.Exodius.Events;
 using AD.Exodius.Events.Factories;
 using AD.Exodius.Navigators;
-using AD.Exodius.Navigators.Strategies;
 using AD.Exodius.Navigators.Strategies.Factories;
-using AD.Exodius.Tests.Stubs.Entities.PageObjects;
+using AD.Exodius.Tests.Stubs.Entities.Pages;
 using AD.Exodius.Tests.Stubs.Navigators.Strategies;
+using NSubstitute;
 
 namespace AD.Exodius.Tests.Navigators;
 
@@ -64,7 +62,7 @@ public class NavigatorTests
 
             stubNavigation.Navigate(_mockDriver, stubPage);
 
-            stubPage.WaitUntilReady();
+            stubPage?.WaitUntilReady();
         });
     }
 

--- a/AD.Exodius.Tests/Navigators/Strategies/ByRouteTests.cs
+++ b/AD.Exodius.Tests/Navigators/Strategies/ByRouteTests.cs
@@ -1,8 +1,8 @@
 ﻿using AD.Exodius.Drivers;
-using AD.Exodius.Navigators.Strategies;
-using NSubstitute;
-using AD.Exodius.Tests.Stubs.Entities.PageObjects;
 using AD.Exodius.Events;
+using AD.Exodius.Navigators.Strategies;
+using AD.Exodius.Tests.Stubs.Entities.Pages;
+using NSubstitute;
 
 namespace AD.Exodius.Tests.Navigators.Strategies;
 
@@ -11,14 +11,12 @@ public class ByRouteTests
     private readonly ByRoute _sut;
     private readonly IDriver _mockDriver;
     private readonly IEventBus _mockEventBus;
-    private readonly StubBasicAttributePageEntity _stubAttributePage;
 
     public ByRouteTests()
     {
         _sut = new ByRoute();
         _mockDriver = Substitute.For<IDriver>();
         _mockEventBus = Substitute.For<IEventBus>();
-        _stubAttributePage = new StubBasicAttributePageEntity(_mockDriver, _mockEventBus);
     }
 
     [Fact]
@@ -26,10 +24,26 @@ public class ByRouteTests
     {
         var expectedRoute = "/basic";
         var expectedUrl = "http://example.com/basic";
+        var page = new StubBasicAttributePageEntity(_mockDriver, _mockEventBus);
 
         _mockDriver.BuildUrlWithRoute(expectedRoute).Returns(expectedUrl);
 
-        await _sut.Navigate(_mockDriver, _stubAttributePage);
+        await _sut.Navigate(_mockDriver, page);
+
+        await _mockDriver.Received(1).GoToUrlAsync(expectedUrl);
+    }
+
+    [Fact]
+    public async Task Navigate_Should_GoToCorrectUrl_WhenQueryStringIsProvided()
+    {
+        var expectedRoute = "/home";
+        var queryString = "?param1=value1&param2=value2";
+        var expectedUrl = "http://example.com/home?param1=value1&param2=value2";
+        var page = new StubMetaPageEntity(_mockDriver, _mockEventBus);
+
+        _mockDriver.BuildUrlWithRoute(expectedRoute + queryString).Returns(expectedUrl);
+
+        await _sut.Navigate(_mockDriver, page);
 
         await _mockDriver.Received(1).GoToUrlAsync(expectedUrl);
     }

--- a/AD.Exodius.Tests/Stubs/Entities/Pages/StubBasicAttributePageEntity.cs
+++ b/AD.Exodius.Tests/Stubs/Entities/Pages/StubBasicAttributePageEntity.cs
@@ -3,7 +3,7 @@ using AD.Exodius.Entities.Pages;
 using AD.Exodius.Entities.Pages.Attributes;
 using AD.Exodius.Events;
 
-namespace AD.Exodius.Tests.Stubs.Entities.PageObjects;
+namespace AD.Exodius.Tests.Stubs.Entities.Pages;
 
 [PageEntitytName("Basic Attribute")]
 [PageEntityRoute("/basic")]

--- a/AD.Exodius.Tests/Stubs/Entities/Pages/StubBasicPageEntity.cs
+++ b/AD.Exodius.Tests/Stubs/Entities/Pages/StubBasicPageEntity.cs
@@ -2,7 +2,7 @@
 using AD.Exodius.Entities.Pages;
 using AD.Exodius.Events;
 
-namespace AD.Exodius.Tests.Stubs.Entities.PageObjects;
+namespace AD.Exodius.Tests.Stubs.Entities.Pages;
 
 public class StubBasicPageEntity(IDriver driver, IEventBus eventBus) : PageEntity(driver, eventBus)
 {

--- a/AD.Exodius.Tests/Stubs/Entities/Pages/StubMetaPageEntity.cs
+++ b/AD.Exodius.Tests/Stubs/Entities/Pages/StubMetaPageEntity.cs
@@ -3,12 +3,13 @@ using AD.Exodius.Entities.Pages;
 using AD.Exodius.Entities.Pages.Attributes;
 using AD.Exodius.Events;
 
-namespace AD.Exodius.Tests.Stubs.Entities.PageObjects;
+namespace AD.Exodius.Tests.Stubs.Entities.Pages;
 
 [PageEntityMeta(
     Route = "/home",
     Name = "Example",
-    DomId = "test"
+    DomId = "test",
+    QueryString = "?param1=value1&param2=value2"
 )]
 public class StubMetaPageEntity(IDriver driver, IEventBus eventBus) : PageEntity(driver, eventBus)
 {

--- a/AD.Exodius.Tests/Stubs/Entities/Pages/StubSampleAttributeEntity.cs
+++ b/AD.Exodius.Tests/Stubs/Entities/Pages/StubSampleAttributeEntity.cs
@@ -3,7 +3,7 @@ using AD.Exodius.Entities.Pages;
 using AD.Exodius.Entities.Pages.Attributes;
 using AD.Exodius.Events;
 
-namespace AD.Exodius.Tests.Stubs.Entities.PageObjects;
+namespace AD.Exodius.Tests.Stubs.Entities.Pages;
 
 [PageEntitytName("Sample Attribute")]
 public class StubSampleAttributeEntity(IDriver driver, IEventBus eventBus) : PageEntity(driver, eventBus)

--- a/AD.Exodius.Tests/Stubs/Entities/Pages/StubTestOwner.cs
+++ b/AD.Exodius.Tests/Stubs/Entities/Pages/StubTestOwner.cs
@@ -4,7 +4,7 @@ using AD.Exodius.Entities.Pages;
 using AD.Exodius.Events;
 using AD.Exodius.Tests.Stubs.Attributes;
 
-namespace AD.Exodius.Tests.Stubs.Entities.PageObjects;
+namespace AD.Exodius.Tests.Stubs.Entities.Pages;
 
 public interface ITestGraph : IEntity { }
 

--- a/AD.Exodius/Entities/Entity.cs
+++ b/AD.Exodius/Entities/Entity.cs
@@ -21,9 +21,9 @@ public class Entity : IEntity
         _unregisteredComponentTypes = [];
     }
 
-    public void AddComponent<TPageComponent>() where TPageComponent : IEntityComponent
+    public void AddComponent<TEntityComponent>() where TEntityComponent : IEntityComponent
     {
-        _unregisteredComponentTypes.Add(typeof(TPageComponent));
+        _unregisteredComponentTypes.Add(typeof(TEntityComponent));
     }
 
     public void AssembleGraph()
@@ -71,24 +71,24 @@ public class Entity : IEntity
         stack.Pop();
     }
 
-    public TPageComponent GetComponent<TPageComponent>() where TPageComponent : IEntityComponent
+    public TEntityComponent GetComponent<TEntityComponent>() where TEntityComponent : IEntityComponent
     {
         var matches = _registeredComponents
-            .OfType<TPageComponent>()
+            .OfType<TEntityComponent>()
             .ToList();
 
         if (matches.Count == 0)
-            throw new InvalidOperationException($"{typeof(TPageComponent).Name} does not exist in the registry.");
+            throw new InvalidOperationException($"{typeof(TEntityComponent).Name} does not exist in the registry.");
 
         if (matches.Count > 1)
-            throw new InvalidOperationException($"Multiple components found for {typeof(TPageComponent).Name}. Use GetComponents<T>() instead.");
+            throw new InvalidOperationException($"Multiple components found for {typeof(TEntityComponent).Name}. Use GetComponents<T>() instead.");
 
         return matches[0];
     }
 
-    public List<TPageComponent> GetComponents<TPageComponent>() where TPageComponent : IEntityComponent
+    public List<TEntityComponent> GetComponents<TEntityComponent>() where TEntityComponent : IEntityComponent
     {
-        return _registeredComponents.OfType<TPageComponent>().ToList();
+        return _registeredComponents.OfType<TEntityComponent>().ToList();
     }
 
     public void InitializeLazyComponents()
@@ -98,8 +98,8 @@ public class Entity : IEntity
             .ForEach(lazyComponent => lazyComponent.Initialize());
     }
 
-    public void RemoveComponent<TPageComponent>() where TPageComponent : IEntityComponent
+    public void RemoveComponent<TEntityComponent>() where TEntityComponent : IEntityComponent
     {
-        _registeredComponents.Remove(GetComponent<TPageComponent>());
+        _registeredComponents.Remove(GetComponent<TEntityComponent>());
     }
 }

--- a/AD.Exodius/Entities/IEntity.cs
+++ b/AD.Exodius/Entities/IEntity.cs
@@ -13,9 +13,9 @@ public interface IEntity
     /// Registers a component type to the graph. Components must implement <see cref="IEntityComponent"/>.
     /// Registration prepares the component for resolution via dependency injection or internal factory mechanisms.
     /// </summary>
-    /// <typeparam name="TPageComponent">The type of the component to register.</typeparam>
+    /// <typeparam name="TEntityComponent">The type of the component to register.</typeparam>
     /// <exception cref="InvalidOperationException">Thrown if the component type is already registered or invalid.</exception>
-    void AddComponent<TPageComponent>() where TPageComponent : IEntityComponent;
+    void AddComponent<TEntityComponent>() where TEntityComponent : IEntityComponent;
 
     /// <summary>
     /// Assembles the component graph by resolving and connecting all registered components and their declared dependencies.
@@ -26,18 +26,18 @@ public interface IEntity
     /// <summary>
     /// Retrieves a single instance of a component from the assembled graph.
     /// </summary>
-    /// <typeparam name="TPageComponent">The type of the component to retrieve.</typeparam>
+    /// <typeparam name="TEntityComponent">The type of the component to retrieve.</typeparam>
     /// <returns>The resolved component instance.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the component has not been assembled in the graph.</exception>
-    TPageComponent GetComponent<TPageComponent>() where TPageComponent : IEntityComponent;
+    TEntityComponent GetComponent<TEntityComponent>() where TEntityComponent : IEntityComponent;
 
     /// <summary>
     /// Retrieves all components of a given type from the graph.
     /// Useful for filtering by base type or interface when multiple implementations exist.
     /// </summary>
-    /// <typeparam name="TPageComponent">The base or interface type to filter components.</typeparam>
+    /// <typeparam name="TEntityComponent">The base or interface type to filter components.</typeparam>
     /// <returns>A list of matching component instances.</returns>
-    List<TPageComponent> GetComponents<TPageComponent>() where TPageComponent : IEntityComponent;
+    List<TEntityComponent> GetComponents<TEntityComponent>() where TEntityComponent : IEntityComponent;
 
     /// <summary>
     /// Initializes all components that implement <see cref="ILazyEntityComponent"/>.
@@ -48,7 +48,7 @@ public interface IEntity
     /// <summary>
     /// Removes a component of the specified type from the graph.
     /// </summary>
-    /// <typeparam name="TPageComponent">The type of the component to remove.</typeparam>
+    /// <typeparam name="TEntityComponent">The type of the component to remove.</typeparam>
     /// <exception cref="InvalidOperationException">Thrown if the component was not previously assembled.</exception>
-    void RemoveComponent<TPageComponent>() where TPageComponent : IEntityComponent;
+    void RemoveComponent<TEntityComponent>() where TEntityComponent : IEntityComponent;
 }

--- a/AD.Exodius/Entities/Pages/Attributes/PageEntityMetaAttribute.cs
+++ b/AD.Exodius/Entities/Pages/Attributes/PageEntityMetaAttribute.cs
@@ -4,6 +4,7 @@
 public class PageEntityMetaAttribute : Attribute
 {
     public string Route { get; set; } = string.Empty;
+    public string QueryString { get; set; } = string.Empty;
     public string DomId { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public Type? Registry { get; set; }
@@ -27,8 +28,14 @@ public class PageEntityMetaAttribute : Attribute
         Name = pageName;
     }
 
-    public PageEntityMetaAttribute(string route, string domId, string pageName, Type registry)
-        : this(route, domId, pageName)
+    public PageEntityMetaAttribute(string route, string domId, string pageName, string queryString)
+    : this(route, domId, pageName)
+    {
+        QueryString = queryString;
+    }
+
+    public PageEntityMetaAttribute(string route, string domId, string pageName, string queryString, Type registry)
+        : this(route, domId, pageName, queryString)
     {
         Registry = registry;
     }

--- a/AD.Exodius/Entities/Pages/PageEntity.cs
+++ b/AD.Exodius/Entities/Pages/PageEntity.cs
@@ -9,7 +9,7 @@ public class PageEntity : Entity, IPageEntity
     public PageEntity(IDriver driver, IEventBus eventBus)
         :base(driver, eventBus)
     {
-        EventBus.SubscribeAsync<PageReadyCheckEvent>(OnReadyCheck);
+        EventBus.Subscribe<PageReadyCheckEvent>(OnReadyCheck);
     }
 
     private async Task OnReadyCheck(PageReadyCheckEvent _)

--- a/AD.Exodius/Events/EventBus.cs
+++ b/AD.Exodius/Events/EventBus.cs
@@ -15,7 +15,7 @@ public class EventBus : IEventBus
         list.Add(handler);
     }
 
-    public void SubscribeAsync<TEvent>(Func<TEvent, Task> handler) where TEvent : IEvent
+    public void Subscribe<TEvent>(Func<TEvent, Task> handler) where TEvent : IEvent
     {
         var type = typeof(TEvent);
         if (!_handlers.TryGetValue(type, out var list))
@@ -26,7 +26,7 @@ public class EventBus : IEventBus
         list.Add(handler);
     }
 
-    public async Task Publish<TEvent>(TEvent publishEvent) where TEvent : IEvent
+    public async Task PublishAsync<TEvent>(TEvent publishEvent) where TEvent : IEvent
     {
         var type = typeof(TEvent);
 

--- a/AD.Exodius/Events/IEventBus.cs
+++ b/AD.Exodius/Events/IEventBus.cs
@@ -3,7 +3,7 @@ namespace AD.Exodius.Events;
 
 public interface IEventBus
 {
-    Task Publish<TEvent>(TEvent publishEvent) where TEvent : IEvent;
+    Task PublishAsync<TEvent>(TEvent publishEvent) where TEvent : IEvent;
     void Subscribe<TEvent>(Action<TEvent> handler) where TEvent : IEvent;
-    void SubscribeAsync<TEvent>(Func<TEvent, Task> handler) where TEvent : IEvent;
+    void Subscribe<TEvent>(Func<TEvent, Task> handler) where TEvent : IEvent;
 }

--- a/AD.Exodius/Helpers/UrlBuilder.cs
+++ b/AD.Exodius/Helpers/UrlBuilder.cs
@@ -55,6 +55,11 @@ public class UrlBuilder
 
         route = route?.TrimStart('/').TrimEnd('/') ?? string.Empty;
 
-        return !string.IsNullOrWhiteSpace(route) ? $"{baseUrl}/{route}/" : baseUrl;
+        if (string.IsNullOrWhiteSpace(route))
+            return baseUrl;
+
+        var hasQuery = route.Contains('?');
+
+        return hasQuery ? $"{baseUrl}/{route}" : $"{baseUrl}/{route}/";
     }
 }

--- a/AD.Exodius/Navigators/Strategies/ByRoute.cs
+++ b/AD.Exodius/Navigators/Strategies/ByRoute.cs
@@ -11,10 +11,18 @@ public class ByRoute : INavigationStrategy
 {
     public async Task Navigate<TPage>(IDriver driver, TPage page) where TPage : IPageEntity
     {
-        var pageEntityMetaRoute = page.TryGetRoute(out var route) ? route : page.TryGetPageEntityMeta(out var meta) ? meta.Route : null;
+        var isEntityMetaPresent = page.TryGetPageEntityMeta(out var entityMeta);
+        var pageEntityMetaRoute = page.TryGetRoute(out var route) ? route : isEntityMetaPresent ? entityMeta?.Route : null;
 
         if (string.IsNullOrEmpty(pageEntityMetaRoute))
             throw new InvalidOperationException($"No Page Meta data as been supplied for Routing on {typeof(TPage).Name}!");
+
+        if (isEntityMetaPresent && !string.IsNullOrEmpty(entityMeta?.QueryString))
+        {
+            var trimmedQueryString = entityMeta.QueryString.TrimStart('?');
+            var separator = pageEntityMetaRoute.Contains('?') ? "&" : "?";
+            pageEntityMetaRoute += separator + trimmedQueryString;
+        }
 
         var newFullPath = driver.BuildUrlWithRoute(pageEntityMetaRoute);
         var currentPath = driver.CurrentUrl();


### PR DESCRIPTION
- Append query string from PageEntityMetaAttribute to route.
- Trim leading ? and choose correct separator (? or &).
- Prevent trailing slash after query string.
- Updated unit tests for query string navigation.
- Added QueryString property to PageEntityMetaAttribute.